### PR TITLE
Chore(deps): Locally update undici to 5.28.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -50,7 +50,7 @@
     discord-api-types "0.37.61"
     magic-bytes.js "^1.5.0"
     tslib "^2.6.2"
-    undici "5.28.3"
+    undici "5.28.4"
 
 "@discordjs/util@^1.0.2":
   version "1.0.2"
@@ -383,7 +383,7 @@ discord.js@^14.14.1:
     fast-deep-equal "3.1.3"
     lodash.snakecase "4.1.1"
     tslib "2.6.2"
-    undici "5.28.3"
+    undici "5.28.4"
     ws "8.14.2"
 
 doctrine@^3.0.0:


### PR DESCRIPTION
5.28.4 is a security release
See: [Undici 5.28.4 Release](https://github.com/nodejs/undici/releases/tag/v5.28.4)